### PR TITLE
Add go.mod file so it can be downloaded using go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tsg/go-daemon
+
+go 1.13


### PR DESCRIPTION
As we are moving towards go modules, this repo needs a `go.mod` file as well. Otherwise, it is not possible to download is using `go`.