### PR TITLE
Add missing go file so repo can be downloaded using go modules

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -1,0 +1,1 @@
+package daemon


### PR DESCRIPTION
A go file was still missing which prevented `go mod` from running successfully.